### PR TITLE
Fix for Ruby 3.0

### DIFF
--- a/lib/credit_card_detector/brand.rb
+++ b/lib/credit_card_detector/brand.rb
@@ -23,7 +23,7 @@ module CreditCardDetector
     end
 
     def rules
-      @rules ||= @raw_rules.map { |rule| Rule.new rule }
+      @rules ||= @raw_rules.map { |rule| Rule.new(length: rule[:length], prefixes: rule[:prefixes]) }
     end
   end
 end

--- a/lib/credit_card_detector/version.rb
+++ b/lib/credit_card_detector/version.rb
@@ -1,4 +1,4 @@
 module CreditCardDetector
-  VERSION = "0.4"
+  VERSION = "0.5"
 end
 


### PR DESCRIPTION
We use this gem at Dotenv.org. It's clean. It's great.

However, we recently upgraded to Ruby 3.0 and ran into this issue related to keywords.

Fix in this PR and backwards compatible with Ruby 2.